### PR TITLE
ZappyIA: Fix wrong path

### DIFF
--- a/src/AI/zappy_ia/IA.py
+++ b/src/AI/zappy_ia/IA.py
@@ -69,7 +69,7 @@ class IA:
         }
 
         try:
-            self.clf = joblib.load("joblib/food.joblib")
+            self.clf = joblib.load("src/AI/joblib/food.joblib")
         except FileNotFoundError:
             print("File joblib not found", file=sys.stderr)
             sys.exit(84)


### PR DESCRIPTION
Comme on a toujours compiler dans src/IA on savait pas que si on lance depuis le root ça marchait pas, et c’est sur dev